### PR TITLE
Update machinepack-strings to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "machinepack-fs": "^12.0.0",
     "machinepack-http": "^6.0.0",
     "machinepack-process": "^4.0.0-0",
-    "machinepack-strings": "^6.0.1",
+    "machinepack-strings": "^6.1.0",
     "mailcomposer": "2.1.0",
     "mailgun-js": "0.13.1",
     "stripe": "5.4.0"


### PR DESCRIPTION
Adds the functionality to provide `len` parameter to the `sails.helpers.strings.random()` function.