### PR TITLE
[proposal] Add the ability to override the default Mailgun host

### DIFF
--- a/lib/private/PARAMETERS.js
+++ b/lib/private/PARAMETERS.js
@@ -171,11 +171,11 @@ module.exports = {
     required: false,
     friendlyName: 'Mailgun host',
     description: 'The Mailgun host to use for sending emails.',
-    extendedDescription: 'Like any other input, this can be set globally using .configure().',
+    extendedDescription: 'Like any other input, this can be set globally using .configure(). If this is not set, the default behavior is to let the "mailgun-js" wrapper library set the default host "api.mailgun.net". ',
     example: 'api.mailgun.net',
     whereToGet: {
       url: 'https://mailgun.com/cp',
-      description: 'Find the correct Mailgun host for your needs. EU based accounts need to use "api.eu.mailgun.net"',
+      description: 'Find the correct Mailgun host for your needs. EU based accounts need to specify "api.eu.mailgun.net", while other accounts won\'t need to set this.',
       extendedDescription: 'You will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
     }
   }

--- a/lib/private/PARAMETERS.js
+++ b/lib/private/PARAMETERS.js
@@ -165,6 +165,18 @@ module.exports = {
       description: 'Copy a domain from either "Mailgun Subdomains" or "Custom Domains" in your Mailgun dashboard.',
       extendedDescription: 'You will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
     }
+  },
+  MAILGUN_HOST: {
+    type: 'string',
+    required: false,
+    friendlyName: 'Mailgun host',
+    description: 'The Mailgun host to use for sending emails.',
+    extendedDescription: 'Like any other input, this can be set globally using .configure().',
+    example: 'api.mailgun.net',
+    whereToGet: {
+      url: 'https://mailgun.com/cp',
+      description: 'Find the correct Mailgun host for your needs. EU based accounts need to use "api.eu.mailgun.net"',
+      extendedDescription: 'You will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
+    }
   }
-
 };

--- a/lib/private/PARAMETERS.js
+++ b/lib/private/PARAMETERS.js
@@ -147,7 +147,7 @@ module.exports = {
     example: 'key-3432afa32e9401482aba183c13f3',
     protect: true,
     whereToGet: {
-      url: 'https://mailgun.com/cp',
+      url: 'https://app.mailgun.com',
       description: 'Copy the "API Key" in your Mailgun dashboard.',
       extendedDescription: 'To retrieve your API key, you will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
     }
@@ -161,21 +161,22 @@ module.exports = {
     extendedDescription: 'Like any other input, this can be set globally using .configure().',
     example: 'sandbox5f89931913a9ab31130131350101.mailgun.og',
     whereToGet: {
-      url: 'https://mailgun.com/cp',
+      url: 'https://app.mailgun.com',
       description: 'Copy a domain from either "Mailgun Subdomains" or "Custom Domains" in your Mailgun dashboard.',
       extendedDescription: 'You will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
     }
   },
+  
   MAILGUN_HOST: {
     type: 'string',
     required: false,
     friendlyName: 'Mailgun host',
-    description: 'The Mailgun host to use for sending emails.',
-    extendedDescription: 'Like any other input, this can be set globally using .configure(). If this is not set, the default behavior is to let the "mailgun-js" wrapper library set the default host "api.mailgun.net". ',
+    description: 'An override to the default Mailgun host to use for sending emails.',
+    extendedDescription: 'Like any other input, this can be set globally using .configure(). If this is not set, this will use the default host as determined by Mailgun.',
     example: 'api.mailgun.net',
     whereToGet: {
-      url: 'https://mailgun.com/cp',
-      description: 'Find the correct Mailgun host for your needs. EU based accounts need to specify "api.eu.mailgun.net", while other accounts won\'t need to set this.',
+      url: 'https://documentation.mailgun.com',
+      description: 'Find the correct Mailgun host for your needs. EU-based accounts need to specify "api.eu.mailgun.net", while other accounts won\'t necessarily need to set this.',
       extendedDescription: 'You will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
     }
   }

--- a/lib/private/mailgun/send-html-email.js
+++ b/lib/private/mailgun/send-html-email.js
@@ -48,6 +48,8 @@ module.exports = {
 
     domain: require('../PARAMETERS').MAILGUN_DOMAIN,
 
+    host: require('../PARAMETERS').MAILGUN_HOST,
+
     toName: {
       example: 'Jane Doe',
       description: 'Full name of the primary recipient.',
@@ -85,11 +87,19 @@ module.exports = {
     var Mailgun = require('mailgun-js');
     var mailcomposer = require('mailcomposer');
 
-    // Initialize the underlying mailgun API wrapper lib.
-    var mailgun = Mailgun({
+    // Mailgun options
+    var mailgunOptions = {
       apiKey: inputs.secret,
       domain: inputs.domain
-    });
+    };
+
+    // Optional Mailgun option host
+    if( inputs.host ){
+      mailgunOptions.host = inputs.host;
+    }
+
+    // Initialize the underlying mailgun API wrapper lib.
+    var mailgun = Mailgun( mailgunOptions );
 
     // Format recipients
     // e.g. 'Jane Doe <jane@example.com>,foo@example.com'.

--- a/lib/private/mailgun/send-html-email.js
+++ b/lib/private/mailgun/send-html-email.js
@@ -87,19 +87,17 @@ module.exports = {
     var Mailgun = require('mailgun-js');
     var mailcomposer = require('mailcomposer');
 
-    // Mailgun options
     var mailgunOptions = {
       apiKey: inputs.secret,
       domain: inputs.domain
     };
 
-    // Optional Mailgun option host
-    if( inputs.host ){
+    if (inputs.host) {
       mailgunOptions.host = inputs.host;
     }
 
     // Initialize the underlying mailgun API wrapper lib.
-    var mailgun = Mailgun( mailgunOptions );
+    var mailgun = Mailgun(mailgunOptions);
 
     // Format recipients
     // e.g. 'Jane Doe <jane@example.com>,foo@example.com'.


### PR DESCRIPTION
This PR addresses the issue discussed on Gitter regarding EU based Mailgun users needing to use 'api.eu.mailgun.net' rather than the default 'api.mailgun.net' as set in 'mailgun-js' when the `host` option is not provided. 

The new feature needed to address this in this hook was discussed and approved by @rachaelshaw.

The change consists of adding the ability to pass in an optional `host` option to the `send-html-email.js`, setting the `host` option if it is set on the inputs, before passing the options to the `Mailgun()`-constructor.

This is tested in a newly generated sails project where I only replaced the affected files, and configured my sandbox-domain, my key and no host, as well as with the `api/hooks/custom/index.js' altered to support setting the `mailgunHost` option in `config/custom.js`.