### PR TITLE
Update `sendHtmlEmail` to resolve security vulnerability and deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@
 language: node_js
 
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
   - "node"
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/private/PARAMETERS.js
+++ b/lib/private/PARAMETERS.js
@@ -166,7 +166,7 @@ module.exports = {
       extendedDescription: 'You will first need to log in to your Mailgun account, or sign up for one if you have not already done so.'
     }
   },
-  
+
   MAILGUN_HOST: {
     type: 'string',
     required: false,

--- a/lib/private/mailgun/send-html-email.js
+++ b/lib/private/mailgun/send-html-email.js
@@ -81,75 +81,54 @@ module.exports = {
   },
 
 
-  fn: function(inputs, exits) {
+  fn: async function({to, subject, htmlMessage, from, fromName, secret, domain, host, toName, textMessage, testMode}) {
 
     // Import dependencies.
-    var Mailgun = require('mailgun-js');
-    var mailcomposer = require('mailcomposer');
+    var Http = require('machinepack-http');
 
-    var mailgunOptions = {
-      apiKey: inputs.secret,
-      domain: inputs.domain
-    };
 
-    if (inputs.host) {
-      mailgunOptions.host = inputs.host;
-    }
-
-    // Initialize the underlying mailgun API wrapper lib.
-    var mailgun = Mailgun(mailgunOptions);
-
-    // Format recipients
-    // e.g. 'Jane Doe <jane@example.com>,foo@example.com'.
-    var formattedRecipients = (function º(){
-      var recipients = [
-        { emailAddress: inputs.to, name: inputs.toName }
-      ];
-      return recipients.map(function(recipient) {
-        if (recipient.name) {
-          return recipient.name+' <'+recipient.emailAddress+'>';
-        } else {
-          return recipient.emailAddress;
-        }
-      }).join(',');
-    })();//º
-
-    // Prepare the email payload.
-    mailcomposer({
-      to: formattedRecipients,
-      subject: inputs.subject,
-      body: inputs.textMessage || '',
-      html: inputs.htmlMessage || '',
+    var data = {
       from: (function º(){
         // e.g. 'John Doe <john@example.com>'
-        if (!inputs.fromName) {
-          return inputs.from;
+        if (!fromName) {
+          return from;
         }
-        return inputs.fromName+' <'+inputs.from+'>';
-      })()//º
+        return fromName+' <'+from+'>';
+      })(),
+      // Format recipients
+      // e.g. 'Jane Doe <jane@example.com>,foo@example.com'.
+      to: (function º(){
+        var recipients = [
+          { emailAddress: to, name: toName }
+        ];
+        return recipients.map(function(recipient) {
+          if (recipient.name) {
+            return recipient.name+' <'+recipient.emailAddress+'>';
+          } else {
+            return recipient.emailAddress;
+          }
+        }).join(',');
+      })(),//º
+      subject: subject,
+      text: textMessage || '',
+      html: htmlMessage || '',
+    };
+
+    if(testMode) {
+      data['o:testmode'] = 'yes';
+    }
+
+    await Http.sendHttpRequest.with({
+      method: 'POST',
+      url: `/${domain}/messages`,
+      baseUrl: `https://api:${secret}@${host || 'api.mailgun.net'}/v3`,
+      body: data,
+      enctype: 'multipart/form-data',
     })
-    .build(function(err, message) {
-      if (err) { return exits.error(err); }
+    .intercept((err)=>{
+      return err;
+    });
 
-      // Note: The old approach of using NODE_ENV was removed deliberately
-      // to avoid unexpected behavior in userland.
-      // ```
-      // var inTestMode;
-      // if (inputs.testMode !== undefined) { inTestMode = inputs.testMode; }
-      // else if (process.env.NODE_ENV === 'production') { inTestMode = false; }
-      // else { inTestMode = true; }//ﬁ
-      // ```
-
-      // Send the mail via Mailgun's `sendMime` API call.
-      mailgun.messages().sendMime({
-        to: formattedRecipients,
-        message: message.toString('ascii'),
-        'o:testmode': inputs.testMode? 'yes' : undefined
-      }, function (err) {
-        if (err) { return exits.error(err); }
-        return exits.success();
-      });//_∏_   </ mailgun…sendMime() >
-    });//_∏_   </ mailcomposer…build() >
   }
 
 };

--- a/lib/private/mailgun/send-html-email.js
+++ b/lib/private/mailgun/send-html-email.js
@@ -124,9 +124,6 @@ module.exports = {
       baseUrl: `https://api:${secret}@${host || 'api.mailgun.net'}/v3`,
       body: data,
       enctype: 'multipart/form-data',
-    })
-    .intercept((err)=>{
-      return err;
     });
 
   }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "machinepack-http": "^7.0.0",
     "machinepack-process": "^4.0.0-0",
     "machinepack-strings": "^6.0.1",
-    "mailcomposer": "2.1.0",
-    "mailgun-js": "0.17.0",
     "stripe": "5.4.0"
   },
   "main": "lib/sails-hook-organics.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "machinepack-process": "^4.0.0-0",
     "machinepack-strings": "^6.0.1",
     "mailcomposer": "2.1.0",
-    "mailgun-js": "0.13.1",
+    "mailgun-js": "0.22.0",
     "stripe": "5.4.0"
   },
   "main": "lib/sails-hook-organics.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "machinepack-process": "^4.0.0-0",
     "machinepack-strings": "^6.0.1",
     "mailcomposer": "2.1.0",
-    "mailgun-js": "0.22.0",
+    "mailgun-js": "0.17.0",
     "stripe": "5.4.0"
   },
   "main": "lib/sails-hook-organics.js",


### PR DESCRIPTION
I tested sending emails in a new sails app with my local sails-hook-organics linked, and didn't have any issues w/ upgrading the version of mailgun-js.