### PR TITLE
Update `mailgun.sendHtmlEmail` to support `bcc`

### DIFF
--- a/lib/private/mailgun/send-html-email.js
+++ b/lib/private/mailgun/send-html-email.js
@@ -44,6 +44,13 @@ module.exports = {
       example: 'Sails Co.'
     },
 
+    bcc: {
+      description:
+        'A list of email addresses of recipients secretly copied on the email.',
+      example: ['jahnna.n.malcolm@example.com'],
+      defaultsTo: [],
+    },
+
     secret: {
       type: 'string',
       required: true,
@@ -117,9 +124,20 @@ module.exports = {
 
   },
 
-
-  fn: async function({to, subject, htmlMessage, from, fromName, secret, domain, host, toName, textMessage, testMode}) {
-
+  fn: async function ({
+    to,
+    subject,
+    htmlMessage,
+    from,
+    fromName,
+    bcc,
+    secret,
+    domain,
+    host,
+    toName,
+    textMessage,
+    testMode,
+  }) {
     // Import dependencies.
     var Http = require('machinepack-http');
 
@@ -150,6 +168,10 @@ module.exports = {
       text: textMessage || '',
       html: htmlMessage || '',
     };
+
+    if (Array.isArray(bcc) && bcc.length) {
+      data.bcc = bcc.join(',');
+    }
 
     if(testMode) {
       data['o:testmode'] = 'yes';


### PR DESCRIPTION
This PR updates `mailgun.sendHtmlEmail` to support `bcc`.

It makes the API of `mailgun.sendHtmlEmail` similar to the API of the newer `sendgrid.sendHtmlEmail`.

When using the `sails new` web app generator, `bcc` is an input in the `sendTemplateEmail` helper.  However, if you switch from the (default) Sendgrid to Mailgun, that `bcc` input can't currently be passed to the Mailgun helper.  Sails trims the `bcc` input and shows this warning:

```
WARNING: Automatically trimmed extraneous values!
In call to sendHtmlEmail(), 1 of the provided values (bcc) does not correspond with any recognized input.
Please try again without the extra value, or check your usage and adjust accordingly.
```

Mailgun's API documenting the `bcc` parameter:
https://documentation.mailgun.com/en/latest/api-sending.html#sending
