### PR TITLE
Upgrade `machinepack-http` dependency & update node versions used in Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@
 language: node_js
 
 node_js:
-  - "6"
-  - "8"
   - "10"
-  - "node"
+  - "12"
+  - "14"
+  - "16"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "async": "2.6.4",
     "bcryptjs": "2.3.0",
     "machinepack-fs": "^12.0.0",
-    "machinepack-http": "^8.0.0",
+    "machinepack-http": "^9.0.0",
     "machinepack-process": "^4.0.0-0",
     "machinepack-strings": "^6.0.1",
     "stripe": "5.4.0"


### PR DESCRIPTION
Changes:
- Updated node versions used in Travis CI tests
- Upgraded `machinepack-http` `^8.0.0` » `^9.0.0`