### PR TITLE
Sendgrid: Add support for replyTo email addresses

### DIFF
--- a/lib/private/sendgrid/send-html-email.js
+++ b/lib/private/sendgrid/send-html-email.js
@@ -132,10 +132,10 @@ module.exports = {
     let replyToAddress;
     if(replyTo){
       if(!replyTo.name){
-        throw new Error('Usage error!: When specifiying a replyTo address, a "name" is required ex: replyTo: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
+        throw new Error('Usage error!: When specifying a replyTo address, a "name" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
       }
       if(!replyTo.email){
-        throw new Error('Usage error!: When specifiying a replyTo address, a "email" is required ex: replyTo: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
+        throw new Error('Usage error!: When specifying a replyTo address, an "email" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
       }
       replyToAddress = replyTo;
     }

--- a/lib/private/sendgrid/send-html-email.js
+++ b/lib/private/sendgrid/send-html-email.js
@@ -130,7 +130,7 @@ module.exports = {
     }
 
     let replyToAddress;
-    if(replyTo){
+    if(replyTo){ // [?]: https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send#request-body
       if(!replyTo.name){
         throw new Error('Usage error!: When specifying a replyTo address, a "name" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
       }

--- a/lib/private/sendgrid/send-html-email.js
+++ b/lib/private/sendgrid/send-html-email.js
@@ -27,7 +27,7 @@ module.exports = {
         email: 'anne.m.martin@example.com',
         name: 'Anne M. Martin'
       },
-      description: 'The reply to email address and name',
+      description: 'The reply to email address and name for the email',
     },
 
     subject: {

--- a/lib/private/sendgrid/send-html-email.js
+++ b/lib/private/sendgrid/send-html-email.js
@@ -132,10 +132,10 @@ module.exports = {
     let replyToAddress;
     if(replyTo){ // [?]: https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send#request-body
       if(!replyTo.name){
-        throw new Error('Usage error!: When specifying a replyTo address, a "name" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
+        throw new Error('Usage error!: When specifying a replyTo address, a "name" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}');
       }
       if(!replyTo.email){
-        throw new Error('Usage error!: When specifying a replyTo address, an "email" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
+        throw new Error('Usage error!: When specifying a replyTo address, an "email" is required ex: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}');
       }
       replyToAddress = replyTo;
     }

--- a/lib/private/sendgrid/send-html-email.js
+++ b/lib/private/sendgrid/send-html-email.js
@@ -22,6 +22,14 @@ module.exports = {
       isEmail: true,
     },
 
+    replyTo: {
+      example: {
+        email: 'anne.m.martin@example.com',
+        name: 'Anne M. Martin'
+      },
+      description: 'The reply to email address and name',
+    },
+
     subject: {
       description: 'Subject line for the email.',
       example: 'Welcome, Anne!',
@@ -101,7 +109,7 @@ module.exports = {
   },
 
 
-  fn: async function({to, subject, htmlMessage, from, fromName, secret, toName, bcc, attachments}) {
+  fn: async function({to, subject, htmlMessage, from, fromName, secret, toName, bcc, attachments, replyTo}) {
 
     // Import dependencies.
     var _ = require('@sailshq/lodash');
@@ -121,6 +129,17 @@ module.exports = {
       });
     }
 
+    let replyToAddress;
+    if(replyTo){
+      if(!replyTo.name){
+        throw new Error('Usage error!: When specifiying a replyTo address, a "name" is required ex: replyTo: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
+      }
+      if(!replyTo.email){
+        throw new Error('Usage error!: When specifiying a replyTo address, a "email" is required ex: replyTo: { email: \'anne.m.martin@example.com\', name: \'Anne M. Martin\'}')
+      }
+      replyToAddress = replyTo;
+    }
+
     var formattedAttachments;
     if(attachments.length > 0) {
       formattedAttachments = attachments.map((attachmentData)=>{
@@ -137,6 +156,7 @@ module.exports = {
         email: from,
         name: fromName
       },
+      reply_to: replyToAddress,// eslint-disable-line camelcase
       personalizations: [personalization],
       attachments: formattedAttachments,
       content: [{


### PR DESCRIPTION
Changes:
- Updated the SendGrid sendHtmlEmail helper to support replyTo email addresses